### PR TITLE
Fix break timer not resetting when break is canceled early

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -235,7 +235,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.pomoState = pomoIdle
 			m.current.Start = time.Time{}
 			m.current.End = time.Time{}
-			cmd = m.saveState()
+			cmd = tea.Batch(m.timer.Reset(), m.saveState())
 		}
 	default:
 		switch m.mode {


### PR DESCRIPTION
## Summary

- Reset the timer when a break is canceled early, matching the existing behavior for `CancelPomoMsg`
- Prevents the countdown from continuing after the user confirms canceling a break

Fixes #13

## Root cause

`CancelBreakMsg` cleared persisted state and set `pomoState` to idle, but did not call `timer.Reset()`. The UI timer kept ticking until it timed out naturally.

## Test plan

- [ ] Start a pomodoro and complete it to enter break mode
- [ ] Press `p` and confirm canceling the break early
- [ ] Verify the timer resets to zero and the footer shows `idle`
- [ ] Verify canceling an active pomodoro still works as before